### PR TITLE
Adicionando o atributo `isIncompleteRegistration` no model de Customer

### DIFF
--- a/src/Models/Customer/Customer.php
+++ b/src/Models/Customer/Customer.php
@@ -189,6 +189,25 @@ class Customer extends Model
         });
     }
 
+    public function isIncompleteRegistration(): Attribute
+    {
+        return Attribute::get(function () {
+            $requiredAttributes = [
+                'name',
+                'document',
+                'civil_status_id',
+                'gender',
+                'birthday',
+            ];
+
+            $hasMissingAttributes = collect($requiredAttributes)->contains(fn ($attribute) => empty($this->$attribute));
+
+            $hasNoContactInfo = empty($this->email) && empty($this->phone) && empty($this->phone_two);
+
+            return $hasMissingAttributes || $hasNoContactInfo;
+        })->shouldCache();
+    }
+
     public function country()
     {
         return $this->belongsTo(Country::class, 'country_id', 'id');


### PR DESCRIPTION
Este pull request introduz um novo método ao modelo `Customer` que determina se o cadastro de um cliente está incompleto. O método verifica se há atributos obrigatórios ausentes e a ausência de informações de contato.

### Nova funcionalidade:

* [`src/Models/Customer/Customer.php`](diffhunk://#diff-f8f4c23d2faf907c0373b397ffd1fe3b9df35eeb638329c70444c0c10ec8b4b8R192-R210): Adicionado o método `isIncompleteRegistration`, que avalia se o cadastro de um cliente está incompleto, verificando se há campos obrigatórios ausentes (`name`, `document`, `civil_status_id`, `gender`, `birthday`) e garantindo que pelo menos um campo de contato (`email`, `phone` ou `phone_two`) esteja presente. O resultado é armazenado em cache para otimização de desempenho.